### PR TITLE
feat: add templ to `SOURCE_EXTENSIONS`

### DIFF
--- a/src/source_detection.rs
+++ b/src/source_detection.rs
@@ -110,19 +110,20 @@ static SOURCE_EXTENSIONS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
 
     // Other Languages
     set.extend(&[
-        "r",    // R
-        "jl",   // Julia
-        "ml",   // OCaml
-        "mli",  // OCaml interface
-        "hs",   // Haskell
-        "lhs",  // Literate Haskell
-        "clj",  // Clojure
-        "cljs", // ClojureScript
-        "cljc", // Clojure Common
-        "bf",   // Brainfuck (why not?)
-        "lisp", // Lisp
-        "el",   // Emacs Lisp
-        "vim",  // Vim script
+        "r",     // R
+        "jl",    // Julia
+        "ml",    // OCaml
+        "mli",   // OCaml interface
+        "hs",    // Haskell
+        "lhs",   // Literate Haskell
+        "clj",   // Clojure
+        "cljs",  // ClojureScript
+        "cljc",  // Clojure Common
+        "bf",    // Brainfuck (why not?)
+        "lisp",  // Lisp
+        "el",    // Emacs Lisp
+        "vim",   // Vim script
+        "templ", // Templ
     ]);
 
     // Build/Config specific
@@ -162,6 +163,7 @@ mod tests {
             ("test.rs", true),
             ("test.py", true),
             ("test.js", true),
+            ("test.templ", true),
             ("test.xyz", false),
             ("test", false),
             ("test.txt", false),


### PR DESCRIPTION
selfishly adding `templ` to `SOURCE_EXTENSIONS`

is there a more scalable way to extend `SOURCE_EXTENSIONS` than having a PR for each extension?

maybe adding something like `additional_extensions: Vec<String>` to `Config`