### PR TITLE
switch from arboard to cli-clipboard to support wayland

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ license = "MIT"
 
 [dependencies]
 anyhow = "1.0.95"
-arboard = "3.4.1"
 clap = { version = "4.5.23", features = ["derive"] }
 colored = "2.2.0"
 crossterm = "0.28.1"
@@ -24,3 +23,4 @@ tiktoken-rs = "0.6.0"
 tokenizers = { version = "0.21.0", features = ["http"] }
 toml = "0.8.19"
 walkdir = "2.5.0"
+cli-clipboard = "0.4.0"

--- a/src/output.rs
+++ b/src/output.rs
@@ -129,7 +129,7 @@ pub fn handle_output(content: String, args: &Cli) -> Result<()> {
 
     // Copy to clipboard if requested
     if !args.print {
-        match arboard::Clipboard::new().and_then(|mut clipboard| clipboard.set_text(content.clone())) {
+        match cli_clipboard::set_contents(content.clone()) {
             Ok(_) => println!("Context prepared! Paste into your LLM of choice + Profit."),
             Err(e) => eprintln!("Warning: Failed to copy to clipboard: {}. Output will continue with other specified formats.", e),
         }


### PR DESCRIPTION
I found that my clipboard wasn't getting set by arboard, and it seems like it just doesn't support wayland's clipboard. 

[cli-clipboard](https://docs.rs/cli-clipboard/latest/cli_clipboard/) seems to work on wayland. It claims to support x11 + wayland + macos + windows.