### PR TITLE
Added PKGBUILD file and AUR helpers installation guide

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,23 +1,21 @@
 # AUR Package Maintainer: Alan <github dot com slash alan-ar1>
 # Upstream Author / Project Maintainer: seatedro <me at seated dot ro>
 
-_pkgbasename=glimpse
-pkgname="$_pkgbasename-rust-git"
+pkgname="glimpse"
 pkgver=r40.4208ee8
 pkgrel=1
 pkgdesc="A blazingly fast tool for peeking at codebases."
 arch=('x86_64' 'aarch64' 'i686')
-url="https://github.com/seatedro/$_pkgbasename"
+url="https://github.com/seatedro/$pkgname"
 license=('MIT')
 makedepends=('git' 'cargo')
-provides=("$_pkgbasename")
-conflicts=("$_pkgbasename")
+conflicts=("$pkgname")
 options=('!lto')
 source=("git+$url")
 sha256sums=('SKIP')
 
 pkgver() {
-  cd "$srcdir/$_pkgbasename"
+  cd "$srcdir/$pkgname"
    ( set -o pipefail
     git describe --long --abbrev=7 2>/dev/null | sed 's/\([^-]*-g\)/r\1/;s/-/./g' ||
     printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short=7 HEAD)"
@@ -25,12 +23,12 @@ pkgver() {
 }
 
 build() {
-    cd "$srcdir/$_pkgbasename"
+    cd "$srcdir/$pkgname"
     cargo build --all-features --release
 }
 
 package() {
-    cd "$srcdir/$_pkgbasename"
-    install -Dm755 "target/release/$_pkgbasename" -t "$pkgdir/usr/bin/"
-    install -Dm644 "LICENSE" -t "$pkgdir/usr/share/licenses/$_pkgbasename"
+    cd "$srcdir/$pkgname"
+    install -Dm755 "target/release/$pkgname" -t "$pkgdir/usr/bin/"
+    install -Dm644 "LICENSE" -t "$pkgdir/usr/share/licenses/$pkgname"
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,5 +1,5 @@
 # AUR Package Maintainer: Alan <github dot com slash alan-ar1>
-# Upstream Author / Project Maintainer: seatedro <seatedro at seated dot ro>
+# Upstream Author / Project Maintainer: seatedro <me at seated dot ro>
 
 _pkgbasename=glimpse
 pkgname="$_pkgbasename-rust-git"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,36 @@
+# AUR Package Maintainer: Alan <github dot com slash alan-ar1>
+# Upstream Author / Project Maintainer: seatedro <seatedro at seated dot ro>
+
+_pkgbasename=glimpse
+pkgname="$_pkgbasename-rust-git"
+pkgver=r40.4208ee8
+pkgrel=1
+pkgdesc="A blazingly fast tool for peeking at codebases."
+arch=('x86_64' 'aarch64' 'i686')
+url="https://github.com/seatedro/$_pkgbasename"
+license=('MIT')
+makedepends=('git' 'cargo')
+provides=("$_pkgbasename")
+conflicts=("$_pkgbasename")
+options=('!lto')
+source=("git+$url")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "$srcdir/$_pkgbasename"
+   ( set -o pipefail
+    git describe --long --abbrev=7 2>/dev/null | sed 's/\([^-]*-g\)/r\1/;s/-/./g' ||
+    printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short=7 HEAD)"
+   )
+}
+
+build() {
+    cd "$srcdir/$_pkgbasename"
+    cargo build --all-features --release
+}
+
+package() {
+    cd "$srcdir/$_pkgbasename"
+    install -Dm755 "target/release/$_pkgbasename" -t "$pkgdir/usr/bin/"
+    install -Dm644 "LICENSE" -t "$pkgdir/usr/share/licenses/$_pkgbasename"
+}

--- a/readme.md
+++ b/readme.md
@@ -40,10 +40,10 @@ nix profile install github:seatedro/glimpse
 Using an AUR helper:
 ```bash
 # Using yay
-yay -S glimpse-rust-git
+yay -S glimpse
 
 # Using paru
-paru -S glimpse-rust-git
+paru -S glimpse
 ```
 
 ## Usage

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,15 @@ nix profile install github:seatedro/glimpse
 }
 ```
 
+Using an AUR helper:
+```bash
+# Using yay
+yay -S glimpse-rust-git
+
+# Using paru
+paru -S glimpse-rust-git
+```
+
 ## Usage
 
 Basic usage:


### PR DESCRIPTION
I've added glimpse to the AUR.

### Overview
- A PKGBUILD file to enable installation via Arch-based distributions.
- Updates to the readme with instructions for using AUR helpers to install the package.

### Testing
- Verified that the PKGBUILD works with standard makepkg workflows.
