### PR TITLE
fix nix profile install on systems without existing ssl cert path

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,9 @@
               darwin.apple_sdk.frameworks.CoreServices
             ];
 
+          preCheck = ''
+            export SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt
+          '';
           checkFlags = [
             "--skip=tokenizer::tests::test_hf_counter"
           ];


### PR DESCRIPTION
Added a pre check to export ssl cert path. Fixes nix profile install and flake install on systems without existing path.