### PR TITLE
Format number when printing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,6 +180,28 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bindgen"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36d860121800b2a9a94f9b5604b332d5cffb234ce17609ea479d723dbc9d3885"
+dependencies = [
+ "bitflags 1.3.2",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 1.0.109",
+ "which",
+]
 
 [[package]]
 name = "bit-set"
@@ -279,6 +307,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,6 +326,17 @@ name = "cfg_aliases"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clap"
@@ -963,6 +1011,7 @@ dependencies = [
  "ignore",
  "indicatif",
  "mockito",
+ "num-format",
  "once_cell",
  "printpdf",
  "ratatui",
@@ -978,6 +1027,12 @@ dependencies = [
  "url",
  "walkdir",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "globset"
@@ -1062,6 +1117,15 @@ dependencies = [
  "serde_json",
  "thiserror",
  "ureq",
+]
+
+[[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1511,6 +1575,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1528,6 +1598,16 @@ dependencies = [
  "libz-sys",
  "openssl-sys",
  "pkg-config",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1805,6 +1885,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "cfg-if",
+ "encoding_rs",
+ "itoa",
+ "lazy_static",
+ "libc",
+ "num-format-windows",
+ "widestring",
+ "winapi",
+]
+
+[[package]]
+name = "num-format-windows"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b1e07f67225c1eb911d16c2f72492669c1fb08212dbfaa1f6cfbeb119152cfa"
+dependencies = [
+ "bindgen",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2052,6 +2158,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
@@ -3509,6 +3621,24 @@ name = "weezl"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
+]
+
+[[package]]
+name = "widestring"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ scraper = "0.18"
 url = "2.5"
 git2 = "0.18"
 mockito = "1.4"
+num-format = { version = "0.4.4", features = ["with-system-locale"] }
 
 [build-dependencies]
 serde = { version = "1.0.217", features = ["derive"] }

--- a/src/output.rs
+++ b/src/output.rs
@@ -49,7 +49,10 @@ pub fn display_token_counts(token_counter: TokenCounter, entries: &[FileEntry]) 
     let token_count = token_counter.count_files(entries)?;
 
     println!("\nToken Count Summary:");
-    println!("Total tokens: {}", token_count.total_tokens);
+    println!(
+        "Total tokens: {}",
+        format_num_with_sep(&token_count.total_tokens)
+    );
     println!("\nBreakdown by file:");
 
     // Sorting breakdown
@@ -58,10 +61,25 @@ pub fn display_token_counts(token_counter: TokenCounter, entries: &[FileEntry]) 
     let top_files = breakdown.iter().take(15);
 
     for (path, count) in top_files {
-        println!("  {}: {}", path.display(), count);
+        println!("  {}: {}", path.display(), format_num_with_sep(count));
     }
 
     Ok(())
+}
+
+fn format_num_with_sep(number: &usize) -> String {
+    let digits = number.to_string();
+    let length = digits.len();
+    let mut out = String::with_capacity(length + length / 3);
+
+    for (i, digit) in digits.chars().rev().enumerate() {
+        if i != 0 && i % 3 == 0 {
+            out.push(',');
+        }
+        out.push(digit);
+    }
+
+    out.chars().rev().collect()
 }
 
 fn generate_tree(entries: &[FileEntry]) -> Result<String> {

--- a/src/output.rs
+++ b/src/output.rs
@@ -69,17 +69,17 @@ pub fn display_token_counts(token_counter: TokenCounter, entries: &[FileEntry]) 
 
 fn format_num_with_sep(number: &usize) -> String {
     let digits = number.to_string();
-    let length = digits.len();
-    let mut out = String::with_capacity(length + length / 3);
+    let len = digits.len();
+    let mut out = String::with_capacity(len + len / 3);
 
-    for (i, digit) in digits.chars().rev().enumerate() {
-        if i != 0 && i % 3 == 0 {
+    for (i, digit) in digits.chars().enumerate() {
+        if i != 0 && (len - i) % 3 == 0 {
             out.push(',');
         }
         out.push(digit);
     }
 
-    out.chars().rev().collect()
+    out
 }
 
 fn generate_tree(entries: &[FileEntry]) -> Result<String> {


### PR DESCRIPTION
Large token counts are hard to read, this PR adds separators to split the number every 3 digits

e.g. `1234567` is formatted to `1,234,567`

Before (top) vs After (bottom)
![image](https://github.com/user-attachments/assets/4ef8cc33-1ee3-458d-94a4-2567633a6fc0)
