### PR TITLE
feat:allow options synced per repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "glimpse"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glimpse"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 description = "A blazingly fast tool for peeking at codebases. Perfect for loading your codebase into an LLM's context."
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
       {
         packages.default = pkgs.rustPlatform.buildRustPackage {
           pname = "glimpse";
-          version = "0.7.4";
+          version = "0.7.5";
 
           src = ./.;
 

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,7 @@ A blazingly fast tool for peeking at codebases. Perfect for loading your codebas
 - 📋 Clipboard support
 - 🎨 Customizable file type detection
 - 🥷 Respects .gitignore automatically
+- 📁 Local per-repo configuration with `.glimpse` file
 - 🔗 Web content processing with Markdown conversion
 - 📦 Git repository support
 - 🌐 URL traversal with configurable depth
@@ -69,6 +70,8 @@ glimpse https://example.com/docs
 glimpse https://example.com/docs --traverse-links --link-depth 2
 ```
 
+On first use in a repository, Glimpse will save a `.glimpse` configuration file locally with your specified options. This file can be referenced on subsequent runs, or overridden by passing options again.
+
 Common options:
 ```bash
 # Show hidden files
@@ -77,16 +80,19 @@ glimpse -H /path/to/project
 # Only show tree structure
 glimpse -o tree /path/to/project
 
-# Copy output to clipboard
-glimpse -c /path/to/project
+# Save output to GLIMPSE.md (default if no path given)
+glimpse -f /path/to/project
 
-# Save output to file
+# Save output to a specific file
 glimpse -f output.txt /path/to/project
+
+# Print output to stdout instead of copying to clipboard
+glimpse -p /path/to/project
 
 # Include specific file types
 glimpse -i "*.rs,*.go" /path/to/project
 
-# Exclude patterns
+# Exclude patterns or files
 glimpse -e "target/*,dist/*" /path/to/project
 
 # Count tokens using tiktoken (OpenAI's tokenizer)
@@ -100,6 +106,15 @@ glimpse --tokenizer huggingface --tokenizer-file /path/to/tokenizer.json /path/t
 
 # Process a Git repository and save as PDF
 glimpse https://github.com/username/repo.git --pdf output.pdf
+
+# Open interactive file picker
+glimpse --interactive /path/to/project
+
+# Print the config file path and exit
+glimpse --config_path
+
+# Initialize a .glimpse config file in the current directory
+glimpse --config
 ```
 
 ## CLI Options
@@ -108,29 +123,31 @@ glimpse https://github.com/username/repo.git --pdf output.pdf
 Usage: glimpse [OPTIONS] [PATH]
 
 Arguments:
-  [PATH]  Directory/Files/URLs to analyze [default: .]
+  [PATH]  Files, directories, or URLs to analyze [default: .]
 
 Options:
-      --interactive              Opens interactive file picker (? for help)
-  -i, --include <PATTERNS>       Additional patterns to include (e.g. "*.rs,*.go")
-  -e, --exclude <PATTERNS>       Additional patterns to exclude
-  -s, --max-size <BYTES>         Maximum file size in bytes
-      --max-depth <DEPTH>        Maximum directory depth to traverse
-  -o, --output <FORMAT>          Output format: tree, files, or both
-  -f, --file <PATH>              Save output to specified file
-  -p, --print                    Print to stdout instead of clipboard
-  -t, --threads <COUNT>          Number of threads for parallel processing
-  -H, --hidden                   Show hidden files and directories
-      --no-ignore                Don't respect .gitignore files
-      --no-tokens                Disable token counting
-      --tokenizer <TYPE>         Tokenizer to use: tiktoken or huggingface
-      --model <NAME>             Model name for HuggingFace tokenizer
-      --tokenizer-file <PATH>    Path to local tokenizer file
-      --traverse-links           Traverse links when processing URLs
-      --link-depth <DEPTH>       Maximum depth to traverse links (default: 1)
-      --pdf <PATH>               Save output as PDF
-  -h, --help                     Print help
-  -V, --version                  Print version
+      --config_path                Print the config file path and exit
+      --config                     Init glimpse config file in current directory
+      --interactive                Opens interactive file picker (? for help)
+  -i, --include <PATTERNS>         Additional patterns to include (e.g. "*.rs,*.go")
+  -e, --exclude <PATTERNS|PATHS>   Additional patterns or files to exclude
+  -s, --max-size <BYTES>           Maximum file size in bytes
+      --max-depth <DEPTH>          Maximum directory depth to traverse
+  -o, --output <FORMAT>            Output format: tree, files, or both
+  -f, --file [<PATH>]              Save output to specified file (default: GLIMPSE.md)
+  -p, --print                      Print to stdout instead of copying to clipboard
+  -t, --threads <COUNT>            Number of threads for parallel processing
+  -H, --hidden                     Show hidden files and directories
+      --no-ignore                  Don't respect .gitignore files
+      --no-tokens                  Disable token counting
+      --tokenizer <TYPE>           Tokenizer to use: tiktoken or huggingface
+      --model <NAME>               Model name for HuggingFace tokenizer
+      --tokenizer-file <PATH>      Path to local tokenizer file
+      --traverse-links             Traverse links when processing URLs
+      --link-depth <DEPTH>         Maximum depth to traverse links (default: 1)
+      --pdf <PATH>                 Save output as PDF
+  -h, --help                       Print help
+  -V, --version                    Print version
 ```
 
 ## Configuration

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -309,6 +309,7 @@ mod tests {
 
     fn create_test_cli(dir_path: &Path) -> Cli {
         Cli {
+            config: false,
             paths: vec![dir_path.to_string_lossy().to_string()],
             config_path: false,
             include: None,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -60,8 +60,12 @@ pub struct Cli {
     pub output: Option<OutputFormat>,
 
     /// Output file path (optional)
-    #[arg(short = 'f', long)]
+    #[arg(short = 'f', long, num_args = 0..=1, default_missing_value = "GLIMPSE.md")]
     pub file: Option<PathBuf>,
+
+    /// Init glimpse config file
+    #[arg(long, default_value_t = false)]
+    pub config: bool,
 
     /// Print to stdout instead
     #[arg(short, long)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
@@ -173,4 +173,47 @@ pub fn get_config_path() -> anyhow::Result<PathBuf> {
         .ok_or_else(|| anyhow::anyhow!("Could not determine config directory"))?
         .join("glimpse");
     Ok(config_dir.join("config.toml"))
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct RepoConfig {
+    pub include: Option<Vec<String>>,
+    pub exclude: Option<Vec<Exclude>>,
+    pub max_size: Option<u64>,
+    pub max_depth: Option<usize>,
+    pub output: Option<BackwardsCompatOutputFormat>,
+    pub file: Option<PathBuf>,
+    pub hidden: Option<bool>,
+    pub no_ignore: Option<bool>,
+}
+
+impl Default for RepoConfig {
+    fn default() -> Self {
+        Self {
+            include: None,
+            exclude: None,
+            max_size: None,
+            max_depth: None,
+            output: None,
+            file: None,
+            hidden: None,
+            no_ignore: None,
+        }
+    }
+}
+
+pub fn save_repo_config(path: &Path, repo_config: &RepoConfig) -> anyhow::Result<()> {
+    let config_str = toml::to_string_pretty(repo_config)?;
+    std::fs::write(path, config_str)?;
+    Ok(())
+}
+
+pub fn load_repo_config(path: &Path) -> anyhow::Result<RepoConfig> {
+    if path.exists() {
+        let config_str = std::fs::read_to_string(path)?;
+        let config: RepoConfig = toml::from_str(&config_str)?;
+        Ok(config)
+    } else {
+        Ok(RepoConfig::default())
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -175,7 +175,7 @@ pub fn get_config_path() -> anyhow::Result<PathBuf> {
     Ok(config_dir.join("config.toml"))
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct RepoConfig {
     pub include: Option<Vec<String>>,
     pub exclude: Option<Vec<Exclude>>,
@@ -185,21 +185,6 @@ pub struct RepoConfig {
     pub file: Option<PathBuf>,
     pub hidden: Option<bool>,
     pub no_ignore: Option<bool>,
-}
-
-impl Default for RepoConfig {
-    fn default() -> Self {
-        Self {
-            include: None,
-            exclude: None,
-            max_size: None,
-            max_depth: None,
-            output: None,
-            file: None,
-            hidden: None,
-            no_ignore: None,
-        }
-    }
 }
 
 pub fn save_repo_config(path: &Path, repo_config: &RepoConfig) -> anyhow::Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,14 +10,31 @@ mod url_processor;
 
 use crate::analyzer::process_directory;
 use crate::cli::Cli;
-use crate::config::{get_config_path, load_config};
+use crate::config::{get_config_path, load_config, load_repo_config, save_repo_config, RepoConfig};
 use crate::git_processor::GitProcessor;
 use crate::url_processor::UrlProcessor;
 use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
+fn is_url_or_git(path: &str) -> bool {
+    GitProcessor::is_git_url(path) || path.starts_with("http://") || path.starts_with("https://")
+}
+
+fn has_custom_options(args: &Cli) -> bool {
+    args.include.is_some()
+        || args.exclude.is_some()
+        || args.max_size.is_some()
+        || args.max_depth.is_some()
+        || args.output.is_some()
+        || args.file.is_some()
+        || args.hidden
+        || args.no_ignore
+}
 
 fn main() -> anyhow::Result<()> {
     let config = load_config()?;
-    let args = Cli::parse_with_config(&config)?;
+    let mut args = Cli::parse_with_config(&config)?;
 
     if args.config_path {
         let path = get_config_path()?;
@@ -28,13 +45,37 @@ fn main() -> anyhow::Result<()> {
     let url_paths: Vec<_> = args
         .paths
         .iter()
-        .filter(|path| {
-            GitProcessor::is_git_url(path)
-                || path.starts_with("http://")
-                || path.starts_with("https://")
-        })
+        .filter(|path| is_url_or_git(path))
         .take(1)
+        .cloned()
         .collect();
+
+    if url_paths.is_empty() && !args.paths.is_empty() {
+        let base_path = PathBuf::from(&args.paths[0]);
+        let root_dir = find_containing_dir_with_glimpse(&base_path)?;
+        let glimpse_file = root_dir.join(".glimpse");
+
+        if args.config {
+            let repo_config = create_repo_config_from_args(&args);
+            save_repo_config(&glimpse_file, &repo_config)?;
+            println!("Configuration saved to {}", glimpse_file.display());
+        } else if glimpse_file.exists() {
+            println!("Loading configuration from {}", glimpse_file.display());
+            let repo_config = load_repo_config(&glimpse_file)?;
+            apply_repo_config(&mut args, &repo_config);
+        } else if has_custom_options(&args) {
+            print!("Would you like to save these options as defaults for this directory? (y/n): ");
+            io::stdout().flush()?;
+            let mut response = String::new();
+            io::stdin().read_line(&mut response)?;
+
+            if response.trim().to_lowercase() == "y" {
+                let repo_config = create_repo_config_from_args(&args);
+                save_repo_config(&glimpse_file, &repo_config)?;
+                println!("Configuration saved to {}", glimpse_file.display());
+            }
+        }
+    }
 
     if url_paths.len() > 1 {
         return Err(anyhow::anyhow!(
@@ -88,8 +129,19 @@ fn main() -> anyhow::Result<()> {
 
             if let Some(output_file) = &args.file {
                 fs::write(output_file, content)?;
+                println!("Output written to: {}", output_file.display());
             } else if args.print {
                 println!("{}", content);
+            } else {
+                // Default behavior for URLs if no -f or --print: copy to clipboard
+                match arboard::Clipboard::new()
+                    .and_then(|mut clipboard| clipboard.set_text(content))
+                {
+                    Ok(_) => println!("URL content copied to clipboard"),
+                    Err(_) => {
+                        println!("Failed to copy to clipboard, use -f to save to a file instead")
+                    }
+                }
             }
         }
     } else {
@@ -98,4 +150,80 @@ fn main() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+fn find_containing_dir_with_glimpse(path: &Path) -> anyhow::Result<PathBuf> {
+    let mut current = if path.is_file() {
+        path.parent().unwrap_or(Path::new(".")).to_path_buf()
+    } else {
+        path.to_path_buf()
+    };
+
+    // Try to find a .glimpse file or go up until we reach the root
+    loop {
+        if current.join(".glimpse").exists() {
+            return Ok(current);
+        }
+
+        if !current.pop() {
+            // If we can't go up anymore, just use the original path
+            return Ok(if path.is_file() {
+                path.parent().unwrap_or(Path::new(".")).to_path_buf()
+            } else {
+                path.to_path_buf()
+            });
+        }
+    }
+}
+
+fn create_repo_config_from_args(args: &Cli) -> RepoConfig {
+    use crate::config::BackwardsCompatOutputFormat;
+
+    RepoConfig {
+        include: args.include.clone(),
+        exclude: args.exclude.clone().map(|v| v.clone()),
+        max_size: args.max_size,
+        max_depth: args.max_depth,
+        output: args
+            .output
+            .clone()
+            .map(|o| BackwardsCompatOutputFormat::from(o)),
+        file: args.file.clone(),
+        hidden: Some(args.hidden),
+        no_ignore: Some(args.no_ignore),
+    }
+}
+
+fn apply_repo_config(args: &mut Cli, repo_config: &RepoConfig) {
+    if let Some(ref include) = repo_config.include {
+        args.include = Some(include.clone());
+    }
+
+    if let Some(ref exclude) = repo_config.exclude {
+        args.exclude = Some(exclude.clone());
+    }
+
+    if let Some(max_size) = repo_config.max_size {
+        args.max_size = Some(max_size);
+    }
+
+    if let Some(max_depth) = repo_config.max_depth {
+        args.max_depth = Some(max_depth);
+    }
+
+    if let Some(ref output) = repo_config.output {
+        args.output = Some((*output).clone().into());
+    }
+
+    if let Some(ref file) = repo_config.file {
+        args.file = Some(file.clone());
+    }
+
+    if let Some(hidden) = repo_config.hidden {
+        args.hidden = hidden;
+    }
+
+    if let Some(no_ignore) = repo_config.no_ignore {
+        args.no_ignore = no_ignore;
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,13 +181,10 @@ fn create_repo_config_from_args(args: &Cli) -> RepoConfig {
 
     RepoConfig {
         include: args.include.clone(),
-        exclude: args.exclude.clone().map(|v| v.clone()),
+        exclude: args.exclude.clone(),
         max_size: args.max_size,
         max_depth: args.max_depth,
-        output: args
-            .output
-            .clone()
-            .map(|o| BackwardsCompatOutputFormat::from(o)),
+        output: args.output.clone().map(BackwardsCompatOutputFormat::from),
         file: args.file.clone(),
         hidden: Some(args.hidden),
         no_ignore: Some(args.no_ignore),

--- a/src/output.rs
+++ b/src/output.rs
@@ -324,6 +324,7 @@ mod tests {
 
         let content = "Test content".to_string();
         let args = Cli {
+            config: false,
             paths: vec![".".to_string()],
             include: None,
             exclude: None,


### PR DESCRIPTION
- **Per-Repository Configuration:**  
  - Glimpse now supports saving and loading a `.glimpse` config file in each project directory.
  - New flags:
    - `--config` to initialize a `.glimpse` config file in the current directory.
  - On first use or when custom options are provided, Glimpse prompts to save them as defaults for the directory.

- **CLI Improvements:**
  - The `-f, --file` flag now accepts an optional path and defaults to `GLIMPSE.md` if no path is given.

- **Documentation & Versioning:**
  - Updated `readme.md` to reflect all new CLI options, behaviors, and usage examples.
  - Bumped version to **0.7.5** in `Cargo.toml`, `Cargo.lock`, and `flake.nix`.

### Usage

- Run `glimpse --config` in your project to create a `.glimpse` file with your preferred options.
- Use `glimpse --config_path` to see which config file is being used.
- All CLI usage and options are now fully documented in the README.
